### PR TITLE
chore: use 2000 bench warmups for better CI measurements

### DIFF
--- a/benchmarks/myers.bench.ts
+++ b/benchmarks/myers.bench.ts
@@ -12,6 +12,7 @@ const b = makeRandomDNAString(1024);
 
 Deno.bench({
   name: "Myers 32bp string JavaScript",
+  warmup: 2000,
   fn: () => {
     myersJS(ax, bx);
   },
@@ -19,6 +20,7 @@ Deno.bench({
 
 Deno.bench({
   name: "Myers 32bp string WebAssembly",
+  warmup: 2000,
   fn: () => {
     myers(ax, bx, false);
   },


### PR DESCRIPTION
Using the default number of warmup iterations showed some unexpected anomalies in CI (though not locally)